### PR TITLE
Changed ffmpeg_cmd var to prioritize seek param

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -193,10 +193,10 @@ do
             else
                channel_str = ' -map 0:v:' .. channel
             end
-            local ffmpeg_cmd = 'ffmpeg -i ' .. self.path ..
+            local ffmpeg_cmd = 'ffmpeg ' .. seek_str ..
+               ' -i ' .. self.path ..
                ' -r ' .. self.fps ..
                ' -t ' .. self.length ..
-               seek_str ..
                channel_str ..
                ' -s ' .. self.width .. 'x' .. self.height ..
                ' -qscale 1' ..


### PR DESCRIPTION
The seek parameter makes the video initialization extremely slow when the parameter is large. Following an explanation here: https://trac.ffmpeg.org/wiki/Seeking , I made the -ss argument appear before the file path.
